### PR TITLE
Prevent script failure when .netrc file starts with # comment.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ exports.parse = function(content) {
     }
     // key=value
     else {
+      m = {};
       m[key] = value;
     }
   }


### PR DESCRIPTION
When the netrc file started with a comment instead of "machine" it would break the script.

/netrc/index.js:57
      m[key] = value;
             ^
TypeError: Cannot set property 'github.com' of null

This fixes it.
