### PR TITLE
Win32compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,11 @@ var fs = require("fs")
  * @api public
  */
 module.exports = exports = function(file) {
-  var home = process.env.HOME || process.env.HOMEPATH;
+  var home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE
+    , platform = require('os').platform();
   
   if(!file && !home) return {};
-  file = file || join(home, ".netrc");
+  file = file || join(home, (platform == "win32"?"_netrc":".netrc"));
 
   if(!file || !fs.existsSync(file)) return {};
   var netrc = fs.readFileSync(file, "UTF-8");

--- a/index.js
+++ b/index.js
@@ -12,11 +12,10 @@ var fs = require("fs")
  * @api public
  */
 module.exports = exports = function(file) {
-  var home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE
-    , platform = require('os').platform();
+  var home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
   
   if(!file && !home) return {};
-  file = file || join(home, (platform == "win32"?"_netrc":".netrc"));
+  file = file || join(home, (/^win/.test(process.platform)?"_netrc":".netrc"));
 
   if(!file || !fs.existsSync(file)) return {};
   var netrc = fs.readFileSync(file, "UTF-8");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netrc",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Parse netrc files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I added a check for process.env.USERPROFILE and a platform check to switch the filename to "_netrc". These changes should make this module work for win32 users. It failed for me before, returning undefined from parse.