### PR TITLE
netrc.save() to write ~/.netrc with 0600 permission, instead of 0644

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ exports.save = function save(machines){
   var home = getHomePath();
   var destFile = join(home, '.netrc');
   var data = exports.format(machines) + '\n';
-  fs.writeFileSync(destFile, data);
+  fs.writeFileSync(destFile, data, {mode: 0o600});
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ exports.save = function save(machines){
   var home = getHomePath();
   var destFile = join(home, '.netrc');
   var data = exports.format(machines) + '\n';
-  fs.writeFileSync(destFile, data, {mode: 0o600});
+  fs.writeFileSync(destFile, data, {mode: '0600'});
 };
 
 /**


### PR DESCRIPTION
~/.netrc contains sensitive informations: login and passwords. It should be not made readable by any other than owner.
