### PR TITLE
Add support for NETRC environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,5 +113,5 @@ exports.save = function save(machines){
  */
 
 function getHomePath() {
-  return process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+  return process.env.NETRC || process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
 }


### PR DESCRIPTION
## Context

According to [GNU netrc documentation](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html#:~:text=netrc%20file-,The%20.,the%20command%20line%20option%20%2DN%20.), the `NETRC` environment variable can be used to specify a directory containing a `.netrc` file:

> The .netrc file contains login and initialization information used by the auto-login process. It generally resides in the user’s home directory, but a location outside of the home directory can be set using the environment variable NETRC.

Currently, this library does not honour the NETRC environment variable.

## Solution

Allow `process.env.NETRC` to override other possible home directories.
